### PR TITLE
Fixed typo in serl_robot_infra/README.md

### DIFF
--- a/serl_robot_infra/README.md
+++ b/serl_robot_infra/README.md
@@ -32,10 +32,10 @@ From there you should be able to navigate to `serl_robot_infra` and then simply 
 conda activate serl
 
 # script to start http server and ros controller
-python serl_robo_infra/robot_servers/franka_server.py \
-    --gripper_type=<Robotiq|Franka|None>
-    --robot_ip=<robot_IP>
-    --gripper_ip=<[Optional] Robotiq_gripper_IP>
+python serl_robot_infra/robot_servers/franka_server.py \
+    --gripper_type=<Robotiq|Franka|None> \
+    --robot_ip=<robot_IP> \
+    --gripper_ip=<[Optional] Robotiq_gripper_IP> \
     --reset_joint_target=<[Optional] robot_joints_when_robot_resets>
 ```
 


### PR DESCRIPTION
Fixed typo in instructions for starting the http server. was `serl_robo_infra...` changed to `serl_robot_infra` Also added backslashes for easier copy pasting to terminal