### PR TITLE
BUG FIX:  While loop not entered in record_transitions.py in bin example

### DIFF
--- a/examples/async_bin_relocation_fwbw_drq/record_transitions.py
+++ b/examples/async_bin_relocation_fwbw_drq/record_transitions.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
             )
 
     # Loop until we have enough transitions
-    while check_all_done():
+    while not check_all_done():
         next_obs, rew, done, truncated, info = env.step(action=np.zeros((7,)))
         next_obs = env.get_front_cam_obs()
         actions = info["intervene_action"]


### PR DESCRIPTION
[check_all_done()](https://github.com/TechnionRL2/serl/blob/586097030bc1ffdaef9b1bba303b618482dc67dd/examples/async_bin_relocation_fwbw_drq/record_transitions.py#L85-L97) returns false if accumulated transitions is smaller than needed transitions. On line 100, check_all_done returns false and never enters the while loop. Fix: put `not` before check_all_done() inline 100 