### PR TITLE
Fix/gym agentlace deps

### DIFF
--- a/docs/sim_quick_start.md
+++ b/docs/sim_quick_start.md
@@ -117,3 +117,47 @@ Run actor node with rendering window:
 # add --ip x.x.x.x if running on a different machine
 bash run_actor.sh
 ```
+
+## Use RLDS logger to save and load trajectories
+
+This provides a way to save and load trajectories for SERL training. [Tensorflow RLDS dataset](https://github.com/google-research/rlds) format is used to save and load trajectories. This standard is compliant with the [RTX datasets](https://robotics-transformer-x.github.io/), which can potentially can be used for other robot learning tasks.
+
+### Installation
+
+This requires additional installation of `oxe_envlogger`:
+```bash
+git clone git@github.com:rail-berkeley/oxe_envlogger.git
+cd oxe_envlogger
+pip install -e .
+```
+
+### Usage
+
+**Save the trajectories**
+
+With the example above, we can save the data from the replay buffer by providing the `rlds_logger_path` argument. This will save the data to the specified path.
+
+```bash
+./run_learner.sh --log_rlds_path /path/to/save
+```
+
+This will save the data to the specified path in the following format:
+
+```bash
+ - /path/to/save
+    - dataset_info.json
+    - features.json
+    - serl_rlds_dataset-train.tfrecord-00000
+    - serl_rlds_dataset-train.tfrecord-00001
+    ....
+```
+
+**Load the trajectories**
+
+With the example above, we can load the data from the replay buffer by providing the `preload_rlds_path` argument. This will load the data from the specified path.
+
+```bash
+./run_learner.sh --preload_rlds_path /path/to/load
+```
+
+This is equivalent to the `--demo_path` argument in `examples/async_rlpd_drq_sim/run_learner.sh` script.

--- a/docs/sim_quick_start.md
+++ b/docs/sim_quick_start.md
@@ -1,5 +1,7 @@
 # Quick Start with SERL in Sim
 
+This is a minimal mujoco simulation environment for training with SERL. The environment consists of a panda robot arm and a cube. The goal is to lift the cube to a target position. The environment is implemented using `franka_sim` and `gym` interface.
+
 ![](./images/franka_sim.png)
 
 ## Installation
@@ -160,4 +162,4 @@ With the example above, we can load the data from the replay buffer by providing
 ./run_learner.sh --preload_rlds_path /path/to/load
 ```
 
-This is equivalent to the `--demo_path` argument in `examples/async_rlpd_drq_sim/run_learner.sh` script.
+This is similar to the `examples/async_rlpd_drq_sim/run_learner.sh` script, which uses `--demo_path` argument which load .pkl offline demo trajectories.

--- a/examples/async_bin_relocation_fwbw_drq/async_drq_randomized.py
+++ b/examples/async_bin_relocation_fwbw_drq/async_drq_randomized.py
@@ -11,8 +11,8 @@ from flax.training import checkpoints
 from copy import deepcopy
 from collections import OrderedDict
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_bin_relocation_fwbw_drq/record_bc_demos.py
+++ b/examples/async_bin_relocation_fwbw_drq/record_bc_demos.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_bin_relocation_fwbw_drq/record_demo.py
+++ b/examples/async_bin_relocation_fwbw_drq/record_demo.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_bin_relocation_fwbw_drq/record_transitions.py
+++ b/examples/async_bin_relocation_fwbw_drq/record_transitions.py
@@ -7,7 +7,7 @@ Usage:
 add `--record_failed_only` to only record failed transitions
 """
 
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_bin_relocation_fwbw_drq/test_classifier.py
+++ b/examples/async_bin_relocation_fwbw_drq/test_classifier.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_bin_relocation_fwbw_drq/train_reward_classifier.py
+++ b/examples/async_bin_relocation_fwbw_drq/train_reward_classifier.py
@@ -7,7 +7,7 @@ from flax.core import frozen_dict
 from flax.training import checkpoints
 import optax
 from tqdm import tqdm
-import gymnasium as gym
+import gym
 import os
 from absl import app, flags
 

--- a/examples/async_cable_route_drq/async_drq_randomized.py
+++ b/examples/async_cable_route_drq/async_drq_randomized.py
@@ -9,8 +9,8 @@ import tqdm
 from absl import app, flags
 from flax.training import checkpoints
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_cable_route_drq/record_demo.py
+++ b/examples/async_cable_route_drq/record_demo.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_cable_route_drq/test_classifier.py
+++ b/examples/async_cable_route_drq/test_classifier.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_cable_route_drq/train_reward_classifier.py
+++ b/examples/async_cable_route_drq/train_reward_classifier.py
@@ -5,7 +5,7 @@ import flax.linen as nn
 from flax.training import checkpoints
 import optax
 from tqdm import tqdm
-import gymnasium as gym
+import gym
 
 from serl_launcher.wrappers.chunking import ChunkingWrapper
 from serl_launcher.utils.train_utils import concat_batches

--- a/examples/async_drq_sim/async_drq_sim.py
+++ b/examples/async_drq_sim/async_drq_sim.py
@@ -24,8 +24,8 @@ from serl_launcher.utils.launcher import (
     make_drq_agent,
     make_trainer_config,
     make_wandb_logger,
+    make_replay_buffer,
 )
-from serl_launcher.data.data_store import MemoryEfficientReplayBufferDataStore
 from serl_launcher.wrappers.serl_obs_wrappers import SERLObsWrapper
 
 import franka_sim
@@ -65,6 +65,9 @@ flags.DEFINE_string("checkpoint_path", None, "Path to save checkpoints.")
 flags.DEFINE_boolean(
     "debug", False, "Debug mode."
 )  # debug mode will disable wandb logging
+
+flags.DEFINE_string("log_rlds_path", None, "Path to save RLDS logs.")
+flags.DEFINE_string("preload_rlds_path", None, "Path to preload RLDS data.")
 
 devices = jax.local_devices()
 num_devices = len(devices)
@@ -138,7 +141,7 @@ def actor(agent: DrQAgent, data_store, env, sampling_rng):
                 next_observations=next_obs,
                 rewards=reward,
                 masks=1.0 - done,
-                dones=done,
+                dones=done or truncated,
             )
             data_store.insert(transition)
 
@@ -291,17 +294,20 @@ def main(_):
     )
 
     def create_replay_buffer_and_wandb_logger():
-        replay_buffer = MemoryEfficientReplayBufferDataStore(
-            env.observation_space,
-            env.action_space,
+        replay_buffer = make_replay_buffer(
+            env,
             capacity=FLAGS.replay_buffer_capacity,
+            rlds_logger_path=FLAGS.log_rlds_path,
+            type="memory_efficient_replay_buffer",
             image_keys=image_keys,
+            preload_rlds_path=FLAGS.preload_rlds_path,
         )
+
         # set up wandb and logging
         wandb_logger = make_wandb_logger(
             project="serl_dev",
             description=FLAGS.exp_name or FLAGS.env,
-            # debug=FLAGS.debug,
+            debug=FLAGS.debug,
         )
         return replay_buffer, wandb_logger
 

--- a/examples/async_drq_sim/async_drq_sim.py
+++ b/examples/async_drq_sim/async_drq_sim.py
@@ -9,8 +9,8 @@ import tqdm
 from absl import app, flags
 from flax.training import checkpoints
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_pcb_insert_drq/async_drq_randomized.py
+++ b/examples/async_pcb_insert_drq/async_drq_randomized.py
@@ -9,8 +9,8 @@ import tqdm
 from absl import app, flags
 from flax.training import checkpoints
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_pcb_insert_drq/record_demo.py
+++ b/examples/async_pcb_insert_drq/record_demo.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_peg_insert_drq/async_drq_randomized.py
+++ b/examples/async_peg_insert_drq/async_drq_randomized.py
@@ -9,8 +9,8 @@ import tqdm
 from absl import app, flags
 from flax.training import checkpoints
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_peg_insert_drq/record_demo.py
+++ b/examples/async_peg_insert_drq/record_demo.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 from tqdm import tqdm
 import numpy as np
 import copy

--- a/examples/async_rlpd_drq_sim/async_rlpd_drq_sim.py
+++ b/examples/async_rlpd_drq_sim/async_rlpd_drq_sim.py
@@ -25,6 +25,7 @@ from serl_launcher.utils.launcher import (
     make_drq_agent,
     make_trainer_config,
     make_wandb_logger,
+    make_replay_buffer,
 )
 from serl_launcher.data.data_store import MemoryEfficientReplayBufferDataStore
 from serl_launcher.wrappers.serl_obs_wrappers import SERLObsWrapper
@@ -67,6 +68,9 @@ flags.DEFINE_string("checkpoint_path", None, "Path to save checkpoints.")
 flags.DEFINE_boolean(
     "debug", False, "Debug mode."
 )  # debug mode will disable wandb logging
+
+flags.DEFINE_string("log_rlds_path", None, "Path to save RLDS logs.")
+flags.DEFINE_string("preload_rlds_path", None, "Path to preload RLDS data.")
 
 devices = jax.local_devices()
 num_devices = len(devices)
@@ -140,7 +144,7 @@ def actor(agent: DrQAgent, data_store, env, sampling_rng):
                 next_observations=next_obs,
                 rewards=reward,
                 masks=1.0 - done,
-                dones=done,
+                dones=done or truncated,
             )
             data_store.insert(transition)
 
@@ -313,12 +317,15 @@ def main(_):
     )
 
     def create_replay_buffer_and_wandb_logger():
-        replay_buffer = MemoryEfficientReplayBufferDataStore(
-            env.observation_space,
-            env.action_space,
+        replay_buffer = make_replay_buffer(
+            env,
             capacity=FLAGS.replay_buffer_capacity,
+            rlds_logger_path=FLAGS.log_rlds_path,
+            type="memory_efficient_replay_buffer",
             image_keys=image_keys,
+            preload_rlds_path=FLAGS.preload_rlds_path,
         )
+
         # set up wandb and logging
         wandb_logger = make_wandb_logger(
             project="serl_dev",

--- a/examples/async_rlpd_drq_sim/async_rlpd_drq_sim.py
+++ b/examples/async_rlpd_drq_sim/async_rlpd_drq_sim.py
@@ -9,8 +9,8 @@ import tqdm
 from absl import app, flags
 from flax.training import checkpoints
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.common.evaluation import evaluate

--- a/examples/async_sac_state_sim/async_sac_state_sim.py
+++ b/examples/async_sac_state_sim/async_sac_state_sim.py
@@ -3,7 +3,7 @@
 import time
 from functools import partial
 
-import gymnasium as gym
+import gym
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -20,7 +20,7 @@ from serl_launcher.utils.launcher import (
     make_replay_buffer,
 )
 
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from serl_launcher.agents.continuous.sac import SACAgent
 from serl_launcher.common.evaluation import evaluate
 from serl_launcher.utils.timer_utils import Timer

--- a/examples/bc_policy.py
+++ b/examples/bc_policy.py
@@ -8,8 +8,8 @@ import numpy as np
 from copy import deepcopy
 import time
 
-import gymnasium as gym
-from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
+import gym
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 
 from serl_launcher.utils.timer_utils import Timer
 from serl_launcher.wrappers.chunking import ChunkingWrapper

--- a/franka_sim/franka_sim/__init__.py
+++ b/franka_sim/franka_sim/__init__.py
@@ -5,7 +5,7 @@ __all__ = [
     "GymRenderingSpec",
 ]
 
-from gymnasium.envs.registration import register
+from gym.envs.registration import register
 
 register(
     id="PandaPickCube-v0",

--- a/franka_sim/franka_sim/envs/panda_pick_gym_env.py
+++ b/franka_sim/franka_sim/envs/panda_pick_gym_env.py
@@ -140,6 +140,7 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
         # NOTE: gymnasium is used here since MujocoRenderer is not available in gym. It
         # is possible to add a similar viewer feature with gym, but that can be a future TODO
         from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
+
         self._viewer = MujocoRenderer(
             self.model,
             self.data,

--- a/franka_sim/franka_sim/envs/panda_pick_gym_env.py
+++ b/franka_sim/franka_sim/envs/panda_pick_gym_env.py
@@ -1,10 +1,17 @@
 from pathlib import Path
 from typing import Any, Literal, Tuple, Dict
 
-import gymnasium as gym
+import gym
 import mujoco
 import numpy as np
-from gymnasium import spaces
+from gym import spaces
+
+try:
+    import mujoco_py
+except ImportError as e:
+    MUJOCO_PY_IMPORT_ERROR = e
+else:
+    MUJOCO_PY_IMPORT_ERROR = None
 
 from franka_sim.controllers import opspace
 from franka_sim.mujoco_gym_env import GymRenderingSpec, MujocoGymEnv
@@ -130,8 +137,9 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
             dtype=np.float32,
         )
 
+        # NOTE: gymnasium is used here since MujocoRenderer is not available in gym. It
+        # is possible to add a similar viewer feature with gym, but that can be a future TODO
         from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
-
         self._viewer = MujocoRenderer(
             self.model,
             self.data,

--- a/franka_sim/franka_sim/mujoco_gym_env.py
+++ b/franka_sim/franka_sim/mujoco_gym_env.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional
 
-import gymnasium as gym
+import gym
 import mujoco
 import numpy as np
 

--- a/franka_sim/franka_sim/test/test_gym_env_render.py
+++ b/franka_sim/franka_sim/test/test_gym_env_render.py
@@ -1,6 +1,6 @@
 import time
 
-import gymnasium as gym
+import gym
 import mujoco
 import mujoco.viewer
 import numpy as np

--- a/franka_sim/requirements.txt
+++ b/franka_sim/requirements.txt
@@ -1,5 +1,6 @@
 dm_env
 mujoco==2.3.7
+gym >= 0.26
 gymnasium
 dm-robotics-transformations
 imageio[ffmpeg]

--- a/serl_launcher/requirements.txt
+++ b/serl_launcher/requirements.txt
@@ -8,9 +8,9 @@ tqdm >= 4.60.0
 chex==0.1.85
 optax==0.1.5
 absl-py >= 0.12.0
-scipy >= 1.6.0
+scipy <= 1.12.0
 wandb >= 0.12.14
-tensorflow==2.15.0
+tensorflow>=2.16.0
 tensorflow_probability>=0.23.0
 einops >= 0.6.1
 imageio >= 2.31.1

--- a/serl_launcher/requirements.txt
+++ b/serl_launcher/requirements.txt
@@ -16,3 +16,4 @@ einops >= 0.6.1
 imageio >= 2.31.1
 moviepy >= 1.0.3
 pre-commit == 3.3.3
+tensorflow_datasets >= 4.4.0

--- a/serl_launcher/serl_launcher/common/evaluation.py
+++ b/serl_launcher/serl_launcher/common/evaluation.py
@@ -2,7 +2,7 @@ import math
 from collections import defaultdict
 from typing import Dict
 
-import gymnasium as gym
+import gym
 import jax
 import numpy as np
 

--- a/serl_launcher/serl_launcher/data/data_store.py
+++ b/serl_launcher/serl_launcher/data/data_store.py
@@ -1,7 +1,7 @@
 from threading import Lock
 from typing import Union, Iterable
 
-import gymnasium as gym
+import gym
 import jax
 from serl_launcher.data.replay_buffer import ReplayBuffer
 from serl_launcher.data.memory_efficient_replay_buffer import (

--- a/serl_launcher/serl_launcher/data/data_store.py
+++ b/serl_launcher/serl_launcher/data/data_store.py
@@ -10,6 +10,18 @@ from serl_launcher.data.memory_efficient_replay_buffer import (
 
 from agentlace.data.data_store import DataStoreBase
 
+from typing import List, Optional, TypeVar
+
+# import oxe_envlogger if it is installed
+try:
+    from oxe_envlogger.rlds_logger import RLDSLogger, RLDSStepType
+except ImportError:
+    print(
+        "rlds logger is not installed, install it if required: "
+        "https://github.com/rail-berkeley/oxe_envlogger "
+    )
+    RLDSLogger = TypeVar("RLDSLogger")
+
 
 class ReplayBufferDataStore(ReplayBuffer, DataStoreBase):
     def __init__(
@@ -17,15 +29,42 @@ class ReplayBufferDataStore(ReplayBuffer, DataStoreBase):
         observation_space: gym.Space,
         action_space: gym.Space,
         capacity: int,
+        rlds_logger: Optional[RLDSLogger] = None,
     ):
         ReplayBuffer.__init__(self, observation_space, action_space, capacity)
         DataStoreBase.__init__(self, capacity)
         self._lock = Lock()
+        self._logger = None
+
+        if rlds_logger:
+            self.step_type = RLDSStepType.TERMINATION  # to init the state for restart
+            self._logger = rlds_logger
 
     # ensure thread safety
-    def insert(self, *args, **kwargs):
+    def insert(self, data):
         with self._lock:
-            super(ReplayBufferDataStore, self).insert(*args, **kwargs)
+            super(ReplayBufferDataStore, self).insert(data)
+
+            # add data to the rlds logger
+            if self._logger:
+                if self.step_type in {
+                    RLDSStepType.TERMINATION,
+                    RLDSStepType.TRUNCATION,
+                }:
+                    self.step_type = RLDSStepType.RESTART
+                elif not data["masks"]:  # 0 is done, 1 is not done
+                    self.step_type = RLDSStepType.TERMINATION
+                elif data["dones"]:
+                    self.step_type = RLDSStepType.TRUNCATION
+                else:
+                    self.step_type = RLDSStepType.TRANSITION
+
+                self._logger(
+                    action=data["actions"],
+                    obs=data["next_observations"],  # TODO: check if this is correct
+                    reward=data["rewards"],
+                    step_type=self.step_type,
+                )
 
     # ensure thread safety
     def sample(self, *args, **kwargs):
@@ -48,17 +87,46 @@ class MemoryEfficientReplayBufferDataStore(MemoryEfficientReplayBuffer, DataStor
         action_space: gym.Space,
         capacity: int,
         image_keys: Iterable[str] = ("image",),
+        rlds_logger: Optional[RLDSLogger] = None,
     ):
         MemoryEfficientReplayBuffer.__init__(
             self, observation_space, action_space, capacity, pixel_keys=image_keys
         )
         DataStoreBase.__init__(self, capacity)
         self._lock = Lock()
+        self._logger = None
+
+        if rlds_logger:
+            self.step_type = RLDSStepType.TERMINATION  # to init the state for restart
+            self._logger = rlds_logger
 
     # ensure thread safety
-    def insert(self, *args, **kwargs):
+    def insert(self, data):
         with self._lock:
-            super(MemoryEfficientReplayBufferDataStore, self).insert(*args, **kwargs)
+            super(MemoryEfficientReplayBufferDataStore, self).insert(data)
+
+            if self._logger:
+                # handle restart when it was done before
+                if self.step_type in {
+                    RLDSStepType.TERMINATION,
+                    RLDSStepType.TRUNCATION,
+                }:
+                    self.step_type = RLDSStepType.RESTART
+                elif self.step_type == RLDSStepType.TRUNCATION:
+                    self.step_type = RLDSStepType.RESTART
+                elif not data["masks"]:  # 0 is done, 1 is not done
+                    self.step_type = RLDSStepType.TERMINATION
+                elif data["dones"]:
+                    self.step_type = RLDSStepType.TRUNCATION
+                else:
+                    self.step_type = RLDSStepType.TRANSITION
+
+                self._logger(
+                    action=data["actions"],
+                    obs=data["next_observations"],  # TODO: not obs, but next_obs
+                    reward=data["rewards"],
+                    step_type=self.step_type,
+                )
 
     # ensure thread safety
     def sample(self, *args, **kwargs):
@@ -85,8 +153,6 @@ def populate_data_store(
     :return data_store
     """
     import pickle as pkl
-    import numpy as np
-    from copy import deepcopy
 
     for demo_path in demos_path:
         with open(demo_path, "rb") as f:

--- a/serl_launcher/serl_launcher/data/dataset.py
+++ b/serl_launcher/serl_launcher/data/dataset.py
@@ -5,7 +5,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from flax.core import frozen_dict
-from gymnasium.utils import seeding
+from gym.utils import seeding
 
 DataType = Union[np.ndarray, Dict[str, "DataType"]]
 DatasetDict = Dict[str, DataType]

--- a/serl_launcher/serl_launcher/data/memory_efficient_replay_buffer.py
+++ b/serl_launcher/serl_launcher/data/memory_efficient_replay_buffer.py
@@ -1,12 +1,12 @@
 import copy
 from typing import Iterable, Optional, Tuple
 
-import gymnasium as gym
+import gym
 import numpy as np
 from serl_launcher.data.dataset import DatasetDict, _sample
 from serl_launcher.data.replay_buffer import ReplayBuffer
 from flax.core import frozen_dict
-from gymnasium.spaces import Box
+from gym.spaces import Box
 
 
 class MemoryEfficientReplayBuffer(ReplayBuffer):

--- a/serl_launcher/serl_launcher/data/replay_buffer.py
+++ b/serl_launcher/serl_launcher/data/replay_buffer.py
@@ -1,7 +1,7 @@
 import collections
 from typing import Any, Iterator, Optional, Sequence, Tuple, Union
 
-import gymnasium as gym
+import gym
 import jax
 import numpy as np
 from serl_launcher.data.dataset import Dataset, DatasetDict

--- a/serl_launcher/serl_launcher/utils/launcher.py
+++ b/serl_launcher/serl_launcher/utils/launcher.py
@@ -196,14 +196,20 @@ def make_replay_buffer(
     capacity: int = 1000000,
     rlds_logger_path: Optional[str] = None,
     type: str = "replay_buffer",
-    image_keys: list = [],  # used when type is "memory_efficient_replay_buffer"
+    image_keys: list = [],  # used only type=="memory_efficient_replay_buffer"
     preload_rlds_path: Optional[str] = None,
 ):
     """
     This is the high-level helper function to
-    create a replay buffer and wandb logger
+    create a replay buffer for the given environment.
 
-    support only for "replay_buffer" and "memory_efficient_replay_buffer"
+    Args:
+    - env: gym or gymasium environment
+    - capacity: capacity of the replay buffer
+    - rlds_logger_path: path to save RLDS logs
+    - type: support only for "replay_buffer" and "memory_efficient_replay_buffer"
+    - image_keys: list of image keys, used only "memory_efficient_replay_buffer"
+    - preload_rlds_path: path to preloaded RLDS trajectories
     """
     print("shape of observation space and action space")
     print(env.observation_space)
@@ -211,7 +217,7 @@ def make_replay_buffer(
 
     # init logger for RLDS
     if rlds_logger_path:
-        # clean this to make this common
+        # from: https://github.com/rail-berkeley/oxe_envlogger
         from oxe_envlogger.rlds_logger import RLDSLogger
 
         rlds_logger = RLDSLogger(

--- a/serl_launcher/serl_launcher/utils/launcher.py
+++ b/serl_launcher/serl_launcher/utils/launcher.py
@@ -3,13 +3,22 @@
 import jax
 from jax import nn
 
+from typing import Optional
+import tensorflow_datasets as tfds
+
 from agentlace.trainer import TrainerConfig
+from agentlace.data.tfds import populate_datastore
 
 from serl_launcher.common.wandb import WandBLogger
 from serl_launcher.agents.continuous.bc import BCAgent
 from serl_launcher.agents.continuous.sac import SACAgent
 from serl_launcher.agents.continuous.drq import DrQAgent
 from serl_launcher.agents.continuous.vice import VICEAgent
+
+from serl_launcher.data.data_store import (
+    MemoryEfficientReplayBufferDataStore,
+    ReplayBufferDataStore,
+)
 
 ##############################################################################
 
@@ -180,3 +189,63 @@ def make_wandb_logger(
         debug=debug,
     )
     return wandb_logger
+
+
+def make_replay_buffer(
+    env,
+    capacity: int = 1000000,
+    rlds_logger_path: Optional[str] = None,
+    type: str = "replay_buffer",
+    image_keys: list = [],  # used when type is "memory_efficient_replay_buffer"
+    preload_rlds_path: Optional[str] = None,
+):
+    """
+    This is the high-level helper function to
+    create a replay buffer and wandb logger
+
+    support only for "replay_buffer" and "memory_efficient_replay_buffer"
+    """
+    print("shape of observation space and action space")
+    print(env.observation_space)
+    print(env.action_space)
+
+    # init logger for RLDS
+    if rlds_logger_path:
+        # clean this to make this common
+        from oxe_envlogger.rlds_logger import RLDSLogger
+
+        rlds_logger = RLDSLogger(
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            dataset_name="serl_rlds_dataset",
+            directory=rlds_logger_path,
+            max_episodes_per_file=5,  # TODO: arbitrary number
+        )
+    else:
+        rlds_logger = None
+
+    if type == "replay_buffer":
+        replay_buffer = ReplayBufferDataStore(
+            env.observation_space,
+            env.action_space,
+            capacity=capacity,
+            rlds_logger=rlds_logger,
+        )
+    elif type == "memory_efficient_replay_buffer":
+        replay_buffer = MemoryEfficientReplayBufferDataStore(
+            env.observation_space,
+            env.action_space,
+            capacity=capacity,
+            rlds_logger=rlds_logger,
+            image_keys=image_keys,
+        )
+    else:
+        raise ValueError(f"Unsupported replay_buffer_type: {type}")
+
+    if preload_rlds_path:
+        print(f" - Preloaded {preload_rlds_path} to replay buffer")
+        dataset = tfds.builder_from_directory(preload_rlds_path).as_dataset(split="all")
+        populate_datastore(replay_buffer, dataset, type="with_dones")
+        print(f" - done populated {len(replay_buffer)} samples to replay buffer")
+
+    return replay_buffer

--- a/serl_launcher/serl_launcher/utils/sim_utils.py
+++ b/serl_launcher/serl_launcher/utils/sim_utils.py
@@ -1,6 +1,6 @@
 from typing import Callable, Union
 
-import gymnasium as gym
+import gym
 import numpy as np
 
 try:

--- a/serl_launcher/serl_launcher/wrappers/chunking.py
+++ b/serl_launcher/serl_launcher/wrappers/chunking.py
@@ -1,8 +1,8 @@
 from collections import deque
 from typing import Optional
 
-import gymnasium as gym
-import gymnasium.spaces
+import gym
+import gym.spaces
 import jax
 import numpy as np
 

--- a/serl_launcher/serl_launcher/wrappers/dmcgym.py
+++ b/serl_launcher/serl_launcher/wrappers/dmcgym.py
@@ -6,7 +6,7 @@ import copy
 from typing import OrderedDict
 
 import dm_env
-import gymnasium as gym
+import gym
 import numpy as np
 from gym import spaces
 

--- a/serl_launcher/serl_launcher/wrappers/front_camera_wrapper.py
+++ b/serl_launcher/serl_launcher/wrappers/front_camera_wrapper.py
@@ -1,5 +1,5 @@
-import gymnasium as gym
-from gymnasium.core import Env
+import gym
+from gym.core import Env
 from copy import deepcopy
 
 

--- a/serl_launcher/serl_launcher/wrappers/mujoco.py
+++ b/serl_launcher/serl_launcher/wrappers/mujoco.py
@@ -1,6 +1,6 @@
 from typing import Callable, Union
 
-import gymnasium as gym
+import gym
 import numpy as np
 from scipy.spatial.transform import Rotation
 

--- a/serl_launcher/serl_launcher/wrappers/norm.py
+++ b/serl_launcher/serl_launcher/wrappers/norm.py
@@ -1,4 +1,4 @@
-import gymnasium as gym
+import gym
 
 
 class UnnormalizeActionProprio(gym.ActionWrapper, gym.ObservationWrapper):

--- a/serl_launcher/serl_launcher/wrappers/remap.py
+++ b/serl_launcher/serl_launcher/wrappers/remap.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-import gymnasium as gym
-import gymnasium.spaces
+import gym
+import gym.spaces
 import jax
 
 

--- a/serl_launcher/serl_launcher/wrappers/roboverse.py
+++ b/serl_launcher/serl_launcher/wrappers/roboverse.py
@@ -1,6 +1,6 @@
 from typing import Callable, Union
 
-import gymnasium as gym
+import gym
 import numpy as np
 
 

--- a/serl_launcher/serl_launcher/wrappers/serl_obs_wrappers.py
+++ b/serl_launcher/serl_launcher/wrappers/serl_obs_wrappers.py
@@ -1,5 +1,5 @@
-import gymnasium as gym
-from gymnasium.spaces import flatten_space, flatten
+import gym
+from gym.spaces import flatten_space, flatten
 
 
 class SERLObsWrapper(gym.ObservationWrapper):

--- a/serl_launcher/serl_launcher/wrappers/video_recorder.py
+++ b/serl_launcher/serl_launcher/wrappers/video_recorder.py
@@ -1,7 +1,7 @@
 import os
 from typing import List, Optional
 
-import gymnasium as gym
+import gym
 import imageio
 import numpy as np
 import tensorflow as tf

--- a/serl_launcher/setup.py
+++ b/serl_launcher/setup.py
@@ -13,7 +13,7 @@ setup(
         "typing_extensions",
         "opencv-python",
         "lz4",
-        "agentlace@git+https://github.com/youliangtan/agentlace.git@2d5d6bff0778d65aa4a589cef2a2bd6f01c645c7",
+        "agentlace@git+https://github.com/youliangtan/agentlace.git@e61032fbce8a1e6d3dc2aeba21de082e4bf46fe3",
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/serl_launcher/setup.py
+++ b/serl_launcher/setup.py
@@ -13,7 +13,7 @@ setup(
         "typing_extensions",
         "opencv-python",
         "lz4",
-        "agentlace@git+https://github.com/youliangtan/agentlace.git@e35c9c5ef440d3cc053a154c47b842f9c12b4356",
+        "agentlace@git+https://github.com/youliangtan/agentlace.git@2d5d6bff0778d65aa4a589cef2a2bd6f01c645c7",
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/serl_launcher/setup.py
+++ b/serl_launcher/setup.py
@@ -13,7 +13,7 @@ setup(
         "typing_extensions",
         "opencv-python",
         "lz4",
-        "agentlace@git+https://github.com/youliangtan/agentlace.git@e61032fbce8a1e6d3dc2aeba21de082e4bf46fe3",
+        "agentlace@git+https://github.com/youliangtan/agentlace.git@892d1557264d7bb1d5df04b37638c850c9d36f35",
     ],
     packages=find_packages(),
     zip_safe=False,

--- a/serl_robot_infra/README.md
+++ b/serl_robot_infra/README.md
@@ -83,7 +83,7 @@ Lastly, we use a gym env interface to interact with the robot server, defined in
 
 Example Usage
 ```py
-import gymnasium as gym
+import gym
 import franka_env
 env = gym.make("FrankaEnv-Vision-v0")
 ```

--- a/serl_robot_infra/franka_env/__init__.py
+++ b/serl_robot_infra/franka_env/__init__.py
@@ -1,4 +1,4 @@
-from gymnasium.envs.registration import register
+from gym.envs.registration import register
 import numpy as np
 
 register(

--- a/serl_robot_infra/franka_env/envs/bin_relocation_env/franka_bin_relocation.py
+++ b/serl_robot_infra/franka_env/envs/bin_relocation_env/franka_bin_relocation.py
@@ -4,7 +4,7 @@ import requests
 import copy
 import cv2
 import queue
-import gymnasium as gym
+import gym
 
 from franka_env.envs.franka_env import FrankaEnv
 from franka_env.utils.rotations import euler_2_quat

--- a/serl_robot_infra/franka_env/envs/franka_env.py
+++ b/serl_robot_infra/franka_env/envs/franka_env.py
@@ -1,6 +1,6 @@
 """Gym Interface for Franka"""
 import numpy as np
-import gymnasium as gym
+import gym
 import cv2
 import copy
 from scipy.spatial.transform import Rotation

--- a/serl_robot_infra/franka_env/envs/pcb_env/franka_pcb_insert.py
+++ b/serl_robot_infra/franka_env/envs/pcb_env/franka_pcb_insert.py
@@ -1,5 +1,5 @@
 import numpy as np
-import gymnasium as gym
+import gym
 import time
 import requests
 import copy

--- a/serl_robot_infra/franka_env/envs/peg_env/franka_peg_insert.py
+++ b/serl_robot_infra/franka_env/envs/peg_env/franka_peg_insert.py
@@ -1,5 +1,5 @@
 import numpy as np
-import gymnasium as gym
+import gym
 import time
 import requests
 import copy

--- a/serl_robot_infra/franka_env/envs/relative_env.py
+++ b/serl_robot_infra/franka_env/envs/relative_env.py
@@ -1,5 +1,5 @@
 from scipy.spatial.transform import Rotation as R
-import gymnasium as gym
+import gym
 import numpy as np
 from gym import Env
 from franka_env.utils.transformations import (

--- a/serl_robot_infra/franka_env/envs/wrappers.py
+++ b/serl_robot_infra/franka_env/envs/wrappers.py
@@ -1,8 +1,8 @@
 import time
-from gymnasium import Env, spaces
-import gymnasium as gym
+from gym import Env, spaces
+import gym
 import numpy as np
-from gymnasium.spaces import Box
+from gym.spaces import Box
 import copy
 from franka_env.spacemouse.spacemouse_expert import SpaceMouseExpert
 from franka_env.utils.rotations import quat_2_euler

--- a/serl_robot_infra/setup.py
+++ b/serl_robot_infra/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.1",
     packages=find_packages(),
     install_requires=[
-        "gymnasium",
+        "gym>=0.26",
         "pyrealsense2",
         "pymodbus==2.5.3",
         "opencv-python",
@@ -18,5 +18,6 @@ setup(
         "requests",
         "flask",
         "defusedxml",
+        "pynput",
     ],
 )


### PR DESCRIPTION
Related to:
- Switch most of the code that were previously using gymnasium to use standard gym (0.26 and above to ensure trunc etc is included). we will still retain gymnasium just the renderer function within the mujoco sim. This should just be a minor issue. All relevant dependencies in the txt and setup.py has been updated. https://github.com/rail-berkeley/serl/issues/44
- Update commit of agentlace. https://github.com/rail-berkeley/serl/issues/43