### PR TITLE
Fix readme jax version installation, reset args bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ We fixed a major issue in the intervention action frame. See release [v0.1.1](ht
 
     - For GPU:
         ```bash
-        pip install --upgrade "jax[cuda12_pip]==0.4.25" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-        pip install --upgrade nvidia-cudnn-cu12==8.9.6.50
+        pip install --upgrade "jax[cuda12]==0.4.28" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
         ```
 
     - For TPU

--- a/examples/bc_policy.py
+++ b/examples/bc_policy.py
@@ -140,13 +140,6 @@ def main(_):
         Training Mode
         """
         sampling_rng = jax.device_put(sampling_rng, device=sharding.replicate())
-        # load demos
-        replay_buffer = MemoryEfficientReplayBufferDataStore(
-            env.observation_space,
-            env.action_space,
-            FLAGS.replay_buffer_capacity,
-            image_keys=image_keys,
-        )
         # load demos and populate to current replay buffer
         replay_buffer = MemoryEfficientReplayBufferDataStore(
             env.observation_space,

--- a/serl_launcher/serl_launcher/wrappers/chunking.py
+++ b/serl_launcher/serl_launcher/wrappers/chunking.py
@@ -72,6 +72,6 @@ class ChunkingWrapper(gym.Wrapper):
         return (stack_obs(self.current_obs), reward, done, trunc, info)
 
     def reset(self, **kwargs):
-        obs, info = self.env.reset()
+        obs, info = self.env.reset(**kwargs)
         self.current_obs.extend([obs] * self.obs_horizon)
         return stack_obs(self.current_obs), info


### PR DESCRIPTION
-  fix jax installation instruction:
    - If install `jax[cuda12] > v0.4.29` will get sharding error due to [api changes](https://github.com/google/jax/releases/tag/jax-v0.4.29) https://github.com/rail-berkeley/serl/pull/61, yet `=0.4.25` still giving weird seg fault. Thus revert to `0.4.28`
- fix chunking reset missing args parsing